### PR TITLE
Add descriptive alt text to event imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,15 +227,15 @@
         </div>
         <p>Our host, RCC's STEM Liason, Brenda Maria sits down with Santiago, RCC's Computer Science Club Co-President to talk RCC's 1st Hackathon and how you can take the first steps to get involved on a path to tech.</p>
       <h3>Events
-      </h3>  
-       <a hreef="https://www.meetup.com/boston-code-and-coffee/"><img src="https://github.com/asiakay/legacy-and-code-roxbury/blob/main/assets/473426600_1040842891404365_8093623291993115551_n.jpg?raw=true" style="width:100%"></a>
-     <a href="https://www.eventbrite.com/e/game-of-deeds-impact-a-thon-tickets-1370416274969?aff=oddtdtcreator"> <img src="https://cdn.glitch.global/de24c1b0-7e4d-497d-9d40-fc14461f0945/Haiti.jpeg?v=1747940448601" width="100%"></a>
+      </h3>
+       <a href="https://www.meetup.com/boston-code-and-coffee/"><img src="https://github.com/asiakay/legacy-and-code-roxbury/blob/main/assets/473426600_1040842891404365_8093623291993115551_n.jpg?raw=true" style="width:100%" alt="Boston Code &amp; Coffee meetup flyer"></a>
+     <a href="https://www.eventbrite.com/e/game-of-deeds-impact-a-thon-tickets-1370416274969?aff=oddtdtcreator"> <img src="https://cdn.glitch.global/de24c1b0-7e4d-497d-9d40-fc14461f0945/Haiti.jpeg?v=1747940448601" width="100%" alt="Game of Deeds Impact-a-Thon flyer"></a>
         <h3>Featured Resources</h3>
-     <a href="https://hackingthearchive.mit.edu/"> <img src="https://github.com/asiakay/legacy-and-code-roxbury/blob/main/assets/wealth-gap-flyer.png?raw=true?raw=true" style="width:100%"></a>
+     <a href="https://hackingthearchive.mit.edu/"> <img src="https://github.com/asiakay/legacy-and-code-roxbury/blob/main/assets/wealth-gap-flyer.png?raw=true?raw=true" style="width:100%" alt="Hacking the Archive wealth gap research flyer"></a>
        <!-- <img src="qrcode.png" alt="Scan for hackathon resources" class="qr-code"> -->
        <!-- <p>Scan for free hackathon prep kit</p> -->
       <p>
-        <a href="https://www.hbcumade.app/"><img src="https://cdn.glitch.global/de24c1b0-7e4d-497d-9d40-fc14461f0945/hbcumade.app.png?v=1747221005024" alt="HBCUmade App" style="width:100%"></a>
+        <a href="https://www.hbcumade.app/"><img src="https://cdn.glitch.global/de24c1b0-7e4d-497d-9d40-fc14461f0945/hbcumade.app.png?v=1747221005024" alt="HBCUmade app promotional graphic" style="width:100%"></a>
       </p>
     </section>
     


### PR DESCRIPTION
## Summary
- add descriptive alt text for each Events and Featured Resources image so screen readers receive the same flyer context
- correct the Boston Code & Coffee link typo so the resource is reachable via keyboard and screen readers

## Testing
- `npx htmlhint index.html` *(fails: registry returned HTTP 403, likely due to network policy)*
- `python - <<'PY' ...` (screen-reader style audit confirming all `<img>` tags expose descriptive alt text)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69151cc72ca08332923eef6c9552ad2c)